### PR TITLE
Refix linter rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,24 +1,23 @@
 {
-  "extends": [
-    "./node_modules/kyt/config/.eslintrc.base.json"
-  ],
+    "extends": [
+        "./node_modules/kyt/config/.eslintrc.base.json"
+    ],
 
-  "env": {
-  },
+    "env": {
+    },
 
-  "plugins": [
-  ],
+    "plugins": [
+    ],
 
-  "rules": {
-      "react/prefer-es6-class": 0,
-      "react/prefer-stateless-function": 0,
-      "object-shorthand": 1,
-      "comma-dangle": 0,
-      "indent": ["error", 2, { "SwitchCase": 2, "VariableDeclarator": 2, "outerIIFEBody": 2 }],
-      "react/jsx-indent-props": ["error", 2],
-      "react/jsx-indent": ["error", 2],
-      "object-shorthand": ["off", "always"],
-      "func-names": ["off", "always"]
-
-  }
+    "rules": {
+        "react/prefer-es6-class": 1,
+        "react/prefer-stateless-function": 0,
+        "object-shorthand": 1,
+        "comma-dangle": 0,
+        "indent": ["error", 4, { "SwitchCase": 1, "VariableDeclarator": 1, "outerIIFEBody": 1 }],
+        "react/jsx-indent-props": ["error", 4],
+        "react/jsx-indent": ["error", 4],
+        "object-shorthand": ["off", "always"],
+        "func-names": ["off", "always"]
+    }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,6 @@
         "indent": ["error", 4, { "SwitchCase": 1, "VariableDeclarator": 1, "outerIIFEBody": 1 }],
         "react/jsx-indent-props": ["error", 4],
         "react/jsx-indent": ["error", 4],
-        "object-shorthand": ["off", "always"],
         "func-names": ["off", "always"]
     }
 }

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -6,13 +6,13 @@ import React from 'react';
 import Sentence from '../Sentence';
 
 const App = React.createClass({
-  render: function () {
-    return (
-      <div>
-        <Sentence />
-      </div>
-    );
-  }
+    render: function () {
+        return (
+            <div>
+                <Sentence />
+            </div>
+        );
+    }
 });
 
 export default App;

--- a/src/components/App/index.test.js
+++ b/src/components/App/index.test.js
@@ -9,6 +9,6 @@ import App from './index';
 import HelloWorld from '../HelloWorld';
 
 it('Tests that the App renders.', () => {
-  const wrapper = shallow(<App />);
-  expect(wrapper.contains(<HelloWorld />)).toBeTruthy();
+    const wrapper = shallow(<App />);
+    expect(wrapper.contains(<HelloWorld />)).toBeTruthy();
 });

--- a/src/components/App/statelessComponentExample.js
+++ b/src/components/App/statelessComponentExample.js
@@ -3,11 +3,11 @@ import HelloWorld from '../HelloWorld';
 
 // ecma6 syntax, and a stateless component
 function App() {
-  return (
-    <div>
-      <HelloWorld />
-    </div>
-  );
+    return (
+        <div>
+            <HelloWorld />
+        </div>
+    );
 }
 
 export default App;

--- a/src/components/HelloWorld/index.js
+++ b/src/components/HelloWorld/index.js
@@ -6,18 +6,18 @@ import React from 'react';
 import styles from './HelloWorld.css';
 
 function HelloWorld() {
-  return (
-    <div className={styles.hello}>
-      <h1>Welcome to the simple React starter-kyt!</h1>
-      <i className={styles.logo} />
-      <h2> This starter-kyt includes:</h2>
-      <ul className={styles.list}>
-        <li>React</li>
-        <li>Express</li>
-        <li>Enzyme</li>
-      </ul>
-    </div>
-  );
+    return (
+        <div className={styles.hello}>
+            <h1>Welcome to the simple React starter-kyt!</h1>
+            <i className={styles.logo} />
+            <h2> This starter-kyt includes:</h2>
+            <ul className={styles.list}>
+                <li>React</li>
+                <li>Express</li>
+                <li>Enzyme</li>
+            </ul>
+        </div>
+    );
 }
 
 export default HelloWorld;

--- a/src/components/Sentence/index.js
+++ b/src/components/Sentence/index.js
@@ -5,74 +5,82 @@
 import React from 'react';
 
 const Sentence = React.createClass({
-  adjectives: [
-    'leathery',
-    'salmony',
-    'beknighted',
-    'scintillating',
-    'flabbergasted',
-    'distracted',
-    'shattered',
-    'foamy',
-    'primitive',
-    'blathery',
-    'crumpled',
-    'tiny'
-  ],
-  nounsSubject: [
-    'handkerchief',
-    'elephant tusk',
-    'umbrella',
-    'big foot',
-  ],
-  nounsObject: [
-    'fancily decorated toothpick',
-    'bunch of blue balloons',
-    'washing machine lint filter with towel fluff in it',
-    'banana with a brown spot'
-  ],
-  verbs: [
-    'skitter',
-    'froth',
-    'zoom forward',
-    'stew',
-    'waggle its little finger',
-    'stomp',
-    'chew a purple gumball',
-    'fray'
-  ],
-  // adverbs: [
-  //   'speedily',
-  //   'clammily',
-  //   'frighteningly',
-  //   'knowingly',
-  //   'blisteringly',
-  //   'alarmingly'
-  // ],
-  pronouns: [
-    'am I',
-    'art thou',
-    'is thee',
-    'are we',
-    'is he',
-    'is she',
-    'is it'
-  ],
-  possessives: [
-    'my',
-    'your',
-    'their',
-    'his',
-    'her',
-    'our'
-  ],
-  getWord: function(wordsArray){
-    const index = Math.floor(Math.random() * wordsArray.length);
-    return wordsArray[index];
-  },
-  render: function() {
-    return <div>Oh {this.getWord(this.adjectives)} {this.getWord(this.nounsSubject)}, <br /> how {this.getWord(this.adjectives)} {this.getWord(this.pronouns)}, <br/> when {this.getWord(this.possessives)} {this.getWord(this.nounsObject)} doth  {this.getWord(this.verbs)}</div>;
-  },
+    adjectives: [
+        'leathery',
+        'salmony',
+        'beknighted',
+        'scintillating',
+        'flabbergasted',
+        'distracted',
+        'shattered',
+        'foamy',
+        'primitive',
+        'blathery',
+        'crumpled',
+        'tiny'
+    ],
+    nounsSubject: [
+        'handkerchief',
+        'elephant tusk',
+        'umbrella',
+        'big foot',
+    ],
+    nounsObject: [
+        'fancily decorated toothpick',
+        'bunch of blue balloons',
+        'washing machine lint filter with towel fluff in it',
+        'banana with a brown spot'
+    ],
+    verbs: [
+        'skitter',
+        'froth',
+        'zoom forward',
+        'stew',
+        'waggle its little finger',
+        'stomp',
+        'chew a purple gumball',
+        'fray'
+    ],
+    // adverbs: [
+    //   'speedily',
+    //   'clammily',
+    //   'frighteningly',
+    //   'knowingly',
+    //   'blisteringly',
+    //   'alarmingly'
+    // ],
+    pronouns: [
+        'am I',
+        'art thou',
+        'is thee',
+        'are we',
+        'is he',
+        'is she',
+        'is it'
+    ],
+    possessives: [
+        'my',
+        'your',
+        'their',
+        'his',
+        'her',
+        'our'
+    ],
+    getWord: function (wordsArray) {
+        const index = Math.floor(Math.random() * wordsArray.length);
+        return wordsArray[index];
+    },
+    render: function () {
+        return (
+            <div>
+                Oh {this.getWord(this.adjectives)} {this.getWord(this.nounsSubject)},
+                <br />
+                how {this.getWord(this.adjectives)} {this.getWord(this.pronouns)},
+                <br />
+                when {this.getWord(this.possessives)} {this.getWord(this.nounsObject)} doth {this.getWord(this.verbs)}
+            </div>
+        );
+    },
 });
 
 export default Sentence;


### PR DESCRIPTION
Looks like some of the linter fixes were overwritten and lost from this original commit: https://github.com/tova-moskowitz/bad_poetry/pull/2/commits/4137532c47935e4d31dc2232bb963eb2a3999072

This PR is to add them back and fix code style/indentation to conform to new linter rules.