### PR TITLE
Allow importing fs module

### DIFF
--- a/kyt.config.js
+++ b/kyt.config.js
@@ -1,4 +1,10 @@
 
 module.exports = {
-  reactHotLoader: true,
+    reactHotLoader: true,
+    modifyWebpackConfig: (baseConfig) => {
+        // Fixes issue preventing importing of fs node module
+        // https://github.com/pugjs/pug-loader/issues/8#issuecomment-55568520
+        baseConfig.node.fs = 'empty';
+        return baseConfig;
+    }
 };


### PR DESCRIPTION
Current webpack configuration throws an error when trying to import the node `fs` package (see https://github.com/pugjs/pug-loader/issues/8#issuecomment-55568520).

The fix is to add the following to webpack config:

```
node: {
  fs: "empty"
}
```